### PR TITLE
Add tinytex binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This repos contains some manifests I use to quickly install and update some appl
 * `TinyTex-min` is infra-only and contains only TexLive with no package installed. We recommand this one if you want Texlive for Windows.
 * `TinyTex-full` contains more packages than `TinyTex`.
 
+See full documentation at https://yihui.org/tinytex/ 
+
+The binaries are synced from https://github.com/yihui/tinytex-releases/releases
+
 ## To install scoop 
 
 See https://github.com/lukesampson/scoop

--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@ This repos contains some manifests I use to quickly install and update some appl
 
 ## Apps in this bucket
 
-* RStudio 1.2 (installer-less)
-* RStudio daily (installer-less)
+### RStudio IDE 
+
+* RStudio 1.2 (installer-less) 
+* RStudio daily (installer-less) - Synced from https://dailies.rstudio.com/
+
+### TinyTex - TexLive distribution
+
+ 3 binaries are available but only one can be installed at the same time. That is because a _shim_ for `tlmgr` command is added to _scoop_ and available to PATH, and that would be overriden. (And honestly, you only need one). 
+
+* `TinyTex` contains several tex packages already installed that are the main one used by Rmarkdown. If you are an R user we recommand this one. 
+* `TinyTex-min` is infra-only and contains only TexLive with no package installed. We recommand this one if you want Texlive for Windows.
+* `TinyTex-full` contains more packages than `TinyTex`.
 
 ## To install scoop 
 
@@ -23,6 +33,13 @@ scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 
 ```powershell
 scoop install rstudio-daily
+scoop install TinyTex
+```
+
+## List installed apps
+
+```powershell
+scoop list
 ```
 
 ## Update an app
@@ -37,4 +54,10 @@ scoop update rstudio-daily
 
 ```powershell
 scoop uninstall rstudio-daily
+```
+
+## check if a tools is found in PATH 
+
+```powershell
+scoop which tlmgr
 ```

--- a/bucket/TinyTex-full.json
+++ b/bucket/TinyTex-full.json
@@ -13,6 +13,10 @@
             "tlmgr"
         ]
     ],
+    "pre_install": [
+      "if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex installed. Run scoop uninstall TinyTex-min if you want to use TinyTex-full.\"}",
+      "if (Test-Path $(appdir Tinytex)) { throw \"You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-full.\"}",
+    ],
     "post_install": [
         "echo \"--> Running tlmgr path add\"",
         "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"

--- a/bucket/TinyTex-full.json
+++ b/bucket/TinyTex-full.json
@@ -14,8 +14,18 @@
         ]
     ],
     "pre_install": [
-      "if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex installed. Run scoop uninstall TinyTex-min if you want to use TinyTex-full.\"}",
+      "if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex-min installed. Run scoop uninstall TinyTex-min if you want to use TinyTex-full.\"}",
+      "catch{",
+      "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+      "scoop uninstall $app",
+      "throw $_",
+      "}",
       "if (Test-Path $(appdir Tinytex)) { throw \"You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-full.\"}",
+      "catch{",
+      "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+      "scoop uninstall $app",
+      "throw $_",
+      "}"
     ],
     "post_install": [
         "echo \"--> Running tlmgr path add\"",

--- a/bucket/TinyTex-full.json
+++ b/bucket/TinyTex-full.json
@@ -1,0 +1,32 @@
+{
+  "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains more LaTeX packages.",  
+  "homepage": "https://yihui.org/tinytex/",
+  "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX.zip",
+  "extract_dir": "TinyTex",
+  "license": "https://tug.org/texlive/LICENSE.TL",
+  "hash": "15723290e2f8ba38a87970b7d9c4e0fa0d52d6236c6eabb9a8b534bad7843ff5",
+  "version": "2020.09",
+  "notes": "For full documentation, see https://yihui.org/tinytex/.",
+  "bin": [
+    [
+      "bin\\win32\\tlmgr.bat",
+      "tlmgr"
+    ]
+  ],
+  "post_install": [
+    "echo \"--> Running tlmgr path add\"",
+    "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
+  ],
+  "uninstaller": {
+    "script": [
+      "echo \"--> Running tlmgr path remove\"",
+      "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
+    ]
+  },
+  "checkver": {
+    "github": "https://github.com/yihui/tinytex-releases"
+  },
+  "autoupdate": {
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX.zip"
+  }
+}

--- a/bucket/TinyTex-full.json
+++ b/bucket/TinyTex-full.json
@@ -1,32 +1,32 @@
 {
-  "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains more LaTeX packages.",  
-  "homepage": "https://yihui.org/tinytex/",
-  "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX.zip",
-  "extract_dir": "TinyTex",
-  "license": "https://tug.org/texlive/LICENSE.TL",
-  "hash": "15723290e2f8ba38a87970b7d9c4e0fa0d52d6236c6eabb9a8b534bad7843ff5",
-  "version": "2020.09",
-  "notes": "For full documentation, see https://yihui.org/tinytex/.",
-  "bin": [
-    [
-      "bin\\win32\\tlmgr.bat",
-      "tlmgr"
-    ]
-  ],
-  "post_install": [
-    "echo \"--> Running tlmgr path add\"",
-    "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
-  ],
-  "uninstaller": {
-    "script": [
-      "echo \"--> Running tlmgr path remove\"",
-      "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
-    ]
-  },
-  "checkver": {
-    "github": "https://github.com/yihui/tinytex-releases"
-  },
-  "autoupdate": {
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX.zip"
-  }
+    "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains more LaTeX packages.",
+    "homepage": "https://yihui.org/tinytex/",
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX.zip",
+    "extract_dir": "TinyTex",
+    "license": "https://tug.org/texlive/LICENSE.TL",
+    "hash": "48155528145826d790640257269705d8b046e0fd47e640dfa84b59d42181bd22",
+    "version": "2020.09",
+    "notes": "For full documentation, see https://yihui.org/tinytex/.",
+    "bin": [
+        [
+            "bin\\win32\\tlmgr.bat",
+            "tlmgr"
+        ]
+    ],
+    "post_install": [
+        "echo \"--> Running tlmgr path add\"",
+        "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
+    ],
+    "uninstaller": {
+        "script": [
+            "echo \"--> Running tlmgr path remove\"",
+            "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/yihui/tinytex-releases"
+    },
+    "autoupdate": {
+        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX.zip"
+    }
 }

--- a/bucket/TinyTex-min.json
+++ b/bucket/TinyTex-min.json
@@ -13,6 +13,10 @@
             "tlmgr"
         ]
     ],
+    "pre_install": [
+      "if (Test-Path $(appdir Tinytex)) { throw \"You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-min.\"}",
+      "if (Test-Path $(appdir TinyTex-full)) { throw \"You already have Tinytex-full installed. Run scoop uninstall TinyTex-full if you want to use TinyTex-min.\"}",
+    ],
     "post_install": [
         "echo \"--> Running tlmgr path add\"",
         "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"

--- a/bucket/TinyTex-min.json
+++ b/bucket/TinyTex-min.json
@@ -15,7 +15,17 @@
     ],
     "pre_install": [
       "if (Test-Path $(appdir Tinytex)) { throw \"You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-min.\"}",
+      "catch{",
+      "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+      "scoop uninstall $app",
+      "throw $_",
+      "}",
       "if (Test-Path $(appdir TinyTex-full)) { throw \"You already have Tinytex-full installed. Run scoop uninstall TinyTex-full if you want to use TinyTex-min.\"}",
+      "catch{",
+      "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+      "scoop uninstall $app",
+      "throw $_",
+      "}"
     ],
     "post_install": [
         "echo \"--> Running tlmgr path add\"",

--- a/bucket/TinyTex-min.json
+++ b/bucket/TinyTex-min.json
@@ -1,32 +1,32 @@
 {
-  "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions is infra-only and contains no packages.",  
-  "homepage": "https://yihui.org/tinytex/",
-  "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX-0.zip",
-  "extract_dir": "TinyTex",
-  "license": "https://tug.org/texlive/LICENSE.TL",
-  "hash": "15723290e2f8ba38a87970b7d9c4e0fa0d52d6236c6eabb9a8b534bad7843ff5",
-  "version": "2020.09",
-  "notes": "For full documentation, see https://yihui.org/tinytex/",
-  "bin": [
-    [
-      "bin\\win32\\tlmgr.bat",
-      "tlmgr"
-    ]
-  ],
-  "post_install": [
-    "echo \"--> Running tlmgr path add\"",
-    "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
-  ],
-  "uninstaller": {
-    "script": [
-      "echo \"--> Running tlmgr path remove\"",
-      "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
-    ]
-  },
-  "checkver": {
-    "github": "https://github.com/yihui/tinytex-releases"
-  },
-  "autoupdate": {
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0.zip"
-  }
+    "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions is infra-only and contains no packages.",
+    "homepage": "https://yihui.org/tinytex/",
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX-0.zip",
+    "extract_dir": "TinyTex",
+    "license": "https://tug.org/texlive/LICENSE.TL",
+    "hash": "2d1600560e0ebf609221e481df7adc3a5612d6657d722b7d6364d70a854573f3",
+    "version": "2020.09",
+    "notes": "For full documentation, see https://yihui.org/tinytex/",
+    "bin": [
+        [
+            "bin\\win32\\tlmgr.bat",
+            "tlmgr"
+        ]
+    ],
+    "post_install": [
+        "echo \"--> Running tlmgr path add\"",
+        "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
+    ],
+    "uninstaller": {
+        "script": [
+            "echo \"--> Running tlmgr path remove\"",
+            "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/yihui/tinytex-releases"
+    },
+    "autoupdate": {
+        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0.zip"
+    }
 }

--- a/bucket/TinyTex-min.json
+++ b/bucket/TinyTex-min.json
@@ -1,0 +1,32 @@
+{
+  "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions is infra-only and contains no packages.",  
+  "homepage": "https://yihui.org/tinytex/",
+  "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX-0.zip",
+  "extract_dir": "TinyTex",
+  "license": "https://tug.org/texlive/LICENSE.TL",
+  "hash": "15723290e2f8ba38a87970b7d9c4e0fa0d52d6236c6eabb9a8b534bad7843ff5",
+  "version": "2020.09",
+  "notes": "For full documentation, see https://yihui.org/tinytex/",
+  "bin": [
+    [
+      "bin\\win32\\tlmgr.bat",
+      "tlmgr"
+    ]
+  ],
+  "post_install": [
+    "echo \"--> Running tlmgr path add\"",
+    "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
+  ],
+  "uninstaller": {
+    "script": [
+      "echo \"--> Running tlmgr path remove\"",
+      "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
+    ]
+  },
+  "checkver": {
+    "github": "https://github.com/yihui/tinytex-releases"
+  },
+  "autoupdate": {
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0.zip"
+  }
+}

--- a/bucket/TinyTex.json
+++ b/bucket/TinyTex.json
@@ -25,5 +25,8 @@
   },
   "checkver": {
     "github": "https://github.com/yihui/tinytex-releases"
+  },
+  "autoupdate": {
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-1.zip"
   }
 }

--- a/bucket/TinyTex.json
+++ b/bucket/TinyTex.json
@@ -14,8 +14,18 @@
     ]
   ],
   "pre_install": [
-    "if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex installed. Run scoop uninstall TinyTex-min if you want to use TinyTex.\"}",
+    "try{if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex-min installed. Run scoop uninstall TinyTex-min if you want to use TinyTex.\"}}",
+    "catch{",
+    "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+    "scoop uninstall $app",
+    "throw $_",
+    "}",
     "if (Test-Path $(appdir TinyTex-full)) { throw \"You already have Tinytex-full installed. Run scoop uninstall TinyTex-full if you want to use TinyTex.\"}",
+    "catch{",
+    "Write-Host \"--> Another TinyTex already found. Cancelling current installation...\" -f red",
+    "scoop uninstall $app",
+    "throw $_",
+    "}"
   ],
   "post_install": [
     "echo \"--> Running tlmgr path add\"",

--- a/bucket/TinyTex.json
+++ b/bucket/TinyTex.json
@@ -1,0 +1,29 @@
+{
+  "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains enough LaTeX packages to compile R Markdown documents. More can be installed by the user.",  
+  "homepage": "https://yihui.org/tinytex/",
+  "url": "https://github.com/yihui/tinytex-releases/releases/download/v2020.09/TinyTeX-1.zip",
+  "extract_dir": "TinyTex",
+  "license": "https://tug.org/texlive/LICENSE.TL",
+  "hash": "15723290e2f8ba38a87970b7d9c4e0fa0d52d6236c6eabb9a8b534bad7843ff5",
+  "version": "2020.09",
+  "notes": "For full documentation, see https://yihui.org/tinytex/",
+  "bin": [
+    [
+      "bin\\win32\\tlmgr.bat",
+      "tlmgr"
+    ]
+  ],
+  "post_install": [
+    "echo \"--> Running tlmgr path add\"",
+    "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"
+  ],
+  "uninstaller": {
+    "script": [
+      "echo \"--> Running tlmgr path remove\"",
+      "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
+    ]
+  },
+  "checkver": {
+    "github": "https://github.com/yihui/tinytex-releases"
+  }
+}

--- a/bucket/TinyTex.json
+++ b/bucket/TinyTex.json
@@ -13,6 +13,10 @@
       "tlmgr"
     ]
   ],
+  "pre_install": [
+    "if (Test-Path $(appdir TinyTex-min)) { throw \"You already have Tinytex installed. Run scoop uninstall TinyTex-min if you want to use TinyTex.\"}",
+    "if (Test-Path $(appdir TinyTex-full)) { throw \"You already have Tinytex-full installed. Run scoop uninstall TinyTex-full if you want to use TinyTex.\"}",
+  ],
   "post_install": [
     "echo \"--> Running tlmgr path add\"",
     "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\win32\\tlmgr.bat path add`\"\" -Wait -NoNewWindow"


### PR DESCRIPTION
Binaries are available in https://github.com/yihui/tinytex-releases and this addition makes them available using scoop. 