### PR TITLE
Fix TinyTeX and tinytex-min manifests for v2026.04 Windows asset rename

### DIFF
--- a/bucket/tinytex-extra.json
+++ b/bucket/tinytex-extra.json
@@ -1,7 +1,7 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains more LaTeX packages.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-v2026.04.zip",
+    "url": "https://github.com/rstudio/tinytex-releases/releases/download/v2026.04/TinyTeX-v2026.04.zip",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
     "hash": "6471849c6f02dfb9ad63f7644191b19ddda8ebf34831c6a06e38e3a06e79e602",
@@ -46,9 +46,9 @@
         ]
     },
     "checkver": {
-        "github": "https://github.com/yihui/tinytex-releases"
+        "github": "https://github.com/rstudio/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-v$version.zip"
+        "url": "https://github.com/rstudio/tinytex-releases/releases/download/v$version/TinyTeX-v$version.zip"
     }
 }

--- a/bucket/tinytex-min.json
+++ b/bucket/tinytex-min.json
@@ -52,7 +52,7 @@
     ],
     "uninstaller": {
         "script": [
-            "tlmgr info --list --only-installed --data name > $env:TMP/tinytex-pkg-installed-$(Get-Date -Format ddMMyyHH).txt",
+            "& \"$dir\\bin\\windows\\tlmgr.bat\" info --list --only-installed --data name > $env:TMP/tinytex-pkg-installed-$(Get-Date -Format ddMMyyHH).txt",
             "echo \"--> Running tlmgr path remove\"",
             "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\windows\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
         ]

--- a/bucket/tinytex-min.json
+++ b/bucket/tinytex-min.json
@@ -1,10 +1,10 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions is infra-only and contains no packages.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-0-v2026.04.zip",
+    "url": "https://github.com/rstudio/tinytex-releases/releases/download/v2026.04/TinyTeX-0-windows-v2026.04.exe",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
-    "hash": "8b5c598429d3ad594a710d26b92bfc3a2060d4ced6ed3dd2923a51af9711062c",
+    "hash": "bf82f904c3dcd33910b0ed719cd9a2b48088b1668fb5c7633ef56efc18efd97c",
     "version": "2026.04",
     "notes": "For full documentation, see https://yihui.org/tinytex/",
     "pre_install": [
@@ -14,13 +14,25 @@
         "scoop uninstall $app",
         "throw $_",
         "}",
-        "try{if (Test-Path $(appdir tinytex-extraa)) { throw \"You already havetinytex-extrara installed. Run scoop uninstaltinytex-extratra if you want to use tinytex-min.\"}}",
+        "try{if (Test-Path $(appdir tinytex-extra)) { throw \"You already have tinytex-extra installed. Run scoop uninstall tinytex-extra if you want to use tinytex-min.\"}}",
         "catch{",
         "Write-Host \"--> Another tinytex installation has been found. Cancelling current installation...\" -f red",
         "scoop uninstall $app",
         "throw $_",
         "}"
     ],
+    "installer": {
+        "script": [
+            "$exe = Get-Item \"$dir\\TinyTeX-*-windows-v*.exe\" | Select-Object -First 1 | Select-Object -ExpandProperty FullName",
+            "Write-Host \"Extracting TinyTeX from $exe...\"",
+            "& 7z x \"$exe\" -o\"$dir\" -y -ba > $null",
+            "if ($LASTEXITCODE -ne 0) { throw 'Failed to extract TinyTeX' }",
+            "Get-ChildItem \"$dir\\TinyTeX\" | Move-Item -Destination $dir -Force",
+            "Remove-Item \"$dir\\TinyTeX\" -ErrorAction SilentlyContinue",
+            "Remove-Item \"$exe\" -Force",
+            "Write-Host 'Extraction complete'"
+        ]
+    },
     "post_install": [
         "echo \"--> Running tlmgr path add\"",
         "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\windows\\tlmgr.bat path add`\"\" -Wait -NoNewWindow",
@@ -49,6 +61,6 @@
         "github": "https://github.com/yihui/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0-v$version.zip"
+        "url": "https://github.com/rstudio/tinytex-releases/releases/download/v$version/TinyTeX-0-windows-v$version.exe"
     }
 }

--- a/bucket/tinytex.json
+++ b/bucket/tinytex.json
@@ -52,7 +52,7 @@
     ],
     "uninstaller": {
         "script": [
-            "tlmgr info --list --only-installed --data name > $env:TMP/tinytex-pkg-installed-$(Get-Date -Format ddMMyyHH).txt",
+            "& \"$dir\\bin\\windows\\tlmgr.bat\" info --list --only-installed --data name > $env:TMP/tinytex-pkg-installed-$(Get-Date -Format ddMMyyHH).txt",
             "echo \"--> Running tlmgr path remove\"",
             "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\windows\\tlmgr.bat path remove`\"\" -Wait -NoNewWindow"
         ]

--- a/bucket/tinytex.json
+++ b/bucket/tinytex.json
@@ -1,10 +1,10 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains enough LaTeX packages to compile R Markdown documents. More can be installed by the user.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-1-v2026.04.zip",
+    "url": "https://github.com/rstudio/tinytex-releases/releases/download/v2026.04/TinyTeX-1-windows-v2026.04.exe",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
-    "hash": "d6390d2a92285d3a34ae9fe8c23b6633ecf9434d433acaba4a21356d5535b0d8",
+    "hash": "1438fc2b5b8a502448cc02fc001f3658b9385f672cd272c2dec5ef89240b92e3",
     "version": "2026.04",
     "notes": "For full documentation, see https://yihui.org/tinytex/",
     "pre_install": [
@@ -21,6 +21,18 @@
         "throw $_",
         "}"
     ],
+    "installer": {
+        "script": [
+            "$exe = Get-Item \"$dir\\TinyTeX-*-windows-v*.exe\" | Select-Object -First 1 | Select-Object -ExpandProperty FullName",
+            "Write-Host \"Extracting TinyTeX from $exe...\"",
+            "& 7z x \"$exe\" -o\"$dir\" -y -ba > $null",
+            "if ($LASTEXITCODE -ne 0) { throw 'Failed to extract TinyTeX' }",
+            "Get-ChildItem \"$dir\\TinyTeX\" | Move-Item -Destination $dir -Force",
+            "Remove-Item \"$dir\\TinyTeX\" -ErrorAction SilentlyContinue",
+            "Remove-Item \"$exe\" -Force",
+            "Write-Host 'Extraction complete'"
+        ]
+    },
     "post_install": [
         "echo \"--> Running tlmgr path add\"",
         "Start-Process \"cmd.exe\" \"/c `\"$dir\\bin\\windows\\tlmgr.bat path add`\"\" -Wait -NoNewWindow",
@@ -49,6 +61,6 @@
         "github": "https://github.com/yihui/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-1-v$version.zip"
+        "url": "https://github.com/rstudio/tinytex-releases/releases/download/v$version/TinyTeX-1-windows-v$version.exe"
     }
 }


### PR DESCRIPTION
TinyTeX upstream switched from .zip to .exe (7-Zip SFX) for Windows assets starting with v2026.04. Updated manifests to:

- tinytex.json: TinyTeX-1-v2026.04.zip → TinyTeX-1-windows-v2026.04.exe
- tinytex-min.json: TinyTeX-0-v2026.04.zip → TinyTeX-0-windows-v2026.04.exe
- tinytex-extra.json: Uses existing TinyTeX-v2026.04.zip (no change needed)

Changes:
- Updated URLs and autoupdate patterns to new .exe naming scheme
- Added installer script to extract 7-Zip SFX exe files and normalize layout
- Recomputed SHA256 hashes for new exe assets
- Fixed pre_install typos in tinytex-min.json
- Updated all three manifests to use canonical rstudio/tinytex-releases repo

Both tinytex.json and tinytex-min.json tested and install successfully.