### PR TITLE
Update TinyTeX to use Windows executable installers

### DIFF
--- a/bucket/tinytex-extra.json
+++ b/bucket/tinytex-extra.json
@@ -1,10 +1,10 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains more LaTeX packages.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-v2026.04.zip",
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-windows-v2026.04.exe#/dl.7z",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
-    "hash": "6471849c6f02dfb9ad63f7644191b19ddda8ebf34831c6a06e38e3a06e79e602",
+    "hash": "ab8c8e391e22103768414d5d304f35dadecb2f8ba673caccdfc5e210be3b09a8",
     "version": "2026.04",
     "notes": "For full documentation, see https://yihui.org/tinytex/.",
     "pre_install": [
@@ -49,6 +49,6 @@
         "github": "https://github.com/yihui/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-v$version.zip"
+        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-windows-v$version.exe#/dl.7z"
     }
 }

--- a/bucket/tinytex-min.json
+++ b/bucket/tinytex-min.json
@@ -14,7 +14,7 @@
         "scoop uninstall $app",
         "throw $_",
         "}",
-        "try{if (Test-Path $(appdir tinytex-extraa)) { throw \"You already havetinytex-extrara installed. Run scoop uninstaltinytex-extratra if you want to use tinytex-min.\"}}",
+        "try{if (Test-Path $(appdir tinytex-extra)) { throw \"You already have tinytex-extra installed. Run scoop uninstall tinytex-extra if you want to use tinytex-min.\"}}",
         "catch{",
         "Write-Host \"--> Another tinytex installation has been found. Cancelling current installation...\" -f red",
         "scoop uninstall $app",

--- a/bucket/tinytex-min.json
+++ b/bucket/tinytex-min.json
@@ -1,10 +1,10 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions is infra-only and contains no packages.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-0-v2026.04.zip",
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-0-windows-v2026.04.exe#/dl.7z",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
-    "hash": "8b5c598429d3ad594a710d26b92bfc3a2060d4ced6ed3dd2923a51af9711062c",
+    "hash": "bf82f904c3dcd33910b0ed719cd9a2b48088b1668fb5c7633ef56efc18efd97c",
     "version": "2026.04",
     "notes": "For full documentation, see https://yihui.org/tinytex/",
     "pre_install": [
@@ -49,6 +49,6 @@
         "github": "https://github.com/yihui/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0-v$version.zip"
+        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-0-windows-v$version.exe#/dl.7z"
     }
 }

--- a/bucket/tinytex.json
+++ b/bucket/tinytex.json
@@ -1,10 +1,10 @@
 {
     "description": "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live. This versions contains enough LaTeX packages to compile R Markdown documents. More can be installed by the user.",
     "homepage": "https://yihui.org/tinytex/",
-    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-1-v2026.04.zip",
+    "url": "https://github.com/yihui/tinytex-releases/releases/download/v2026.04/TinyTeX-1-windows-v2026.04.exe#/dl.7z",
     "extract_dir": "TinyTeX",
     "license": "https://tug.org/texlive/LICENSE.TL",
-    "hash": "d6390d2a92285d3a34ae9fe8c23b6633ecf9434d433acaba4a21356d5535b0d8",
+    "hash": "1438fc2b5b8a502448cc02fc001f3658b9385f672cd272c2dec5ef89240b92e3",
     "version": "2026.04",
     "notes": "For full documentation, see https://yihui.org/tinytex/",
     "pre_install": [
@@ -49,6 +49,6 @@
         "github": "https://github.com/yihui/tinytex-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-1-v$version.zip"
+        "url": "https://github.com/yihui/tinytex-releases/releases/download/v$version/TinyTeX-1-windows-v$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
## Summary
Updated both TinyTeX and TinyTeX-min package manifests to use Windows executable installers (.exe) instead of ZIP archives, with corresponding hash updates.

## Key Changes
- **tinytex-min.json**: Changed download URL from `TinyTeX-0-v2026.04.zip` to `TinyTeX-0-windows-v2026.04.exe#/dl.7z`
- **tinytex.json**: Changed download URL from `TinyTeX-1-v2026.04.zip` to `TinyTeX-1-windows-v2026.04.exe#/dl.7z`
- Updated SHA256 hashes for both packages to match the new executable installers
- Updated autoupdate patterns in both manifests to use the new Windows executable format with `.exe#/dl.7z` extraction

## Implementation Details
- The `.exe#/dl.7z` syntax indicates that Scoop will extract the 7z archive embedded within the executable installer
- Both the minimal (infra-only) and full TinyTeX distributions now use the same installer format
- The `extract_dir` remains "TinyTeX" for both packages, ensuring consistent extraction behavior

https://claude.ai/code/session_01PV8dPQtPFkt9hmznmGmbi6